### PR TITLE
bug(860010): The folder name in the access denied error message has been corrected.

### DIFF
--- a/Models/PhysicalFileProvider.cs
+++ b/Models/PhysicalFileProvider.cs
@@ -2304,8 +2304,8 @@ namespace Syncfusion.EJ2.FileManager.PhysicalFileProvider
         }
         private string getFileNameFromPath(string path)
         {
-            int index = path.LastIndexOf("/");
-            return path.Substring(index + 1);
+            string[] segments = path.TrimEnd('/').Split('/');
+            return segments.LastOrDefault();
         }
 
     }


### PR DESCRIPTION
### Bug description

- In Blazor File Manager component, incorrect folder name returned in the access permission error message.

### Root cause

-  The issue occurs due to the incorrect folder name returned from the provider method.

### Solution description

-  Corrected the folder name properly with proper path split up.

### Reason for not identifying earlier
 * [ ] Guidelines not followed. If yes, provide which guideline is not followed.

 * [ ] Guidelines not given. If yes, provide which/who need to address.
    Tag label `update-guideline-coreteam` or `update-guideline-productteam`. 

 * [x] If any other reason, provide the details here. 

#### Areas tested against this fix

- Provide details about the areas or combinations that have been tested against these code changes.

* I have ensured the basic sample of the File Manager.
 
### Is it a breaking issue?
* []  Yes, Tag `breaking-issue`. 
* [x]  NO

 If yes, provide the breaking commit details / MR here.

 ### Output Screenshot
NA

## Reviewer Checklist
* [x]  All provided information are reviewed and ensured.