### PR TITLE
Resolved the folder not found when running the File Provider on Linux

### DIFF
--- a/Controllers/FileManagerAccessController.cs
+++ b/Controllers/FileManagerAccessController.cs
@@ -19,12 +19,12 @@ namespace EJ2APIServices.Controllers
     {
         public PhysicalFileProvider operation;
         public string basePath;
-        string root = "wwwroot\\Files";
+        string root = $"wwwroot{Path.DirectorySeparatorChar}Files";
         public FileManagerAccessController(IWebHostEnvironment hostingEnvironment)
         {
             this.basePath = hostingEnvironment.ContentRootPath;
             this.operation = new PhysicalFileProvider();
-            this.operation.RootFolder(this.basePath + "\\" + this.root);
+            this.operation.RootFolder($"{this.basePath}{Path.DirectorySeparatorChar}{this.root}");
         }
         [Route("FileOperations")]
         public object FileOperations([FromBody] FileManagerDirectoryContent args)

--- a/Controllers/FileManagerController.cs
+++ b/Controllers/FileManagerController.cs
@@ -19,12 +19,12 @@ namespace EJ2APIServices.Controllers
     {
         public PhysicalFileProvider operation;
         public string basePath;
-        string root = "wwwroot\\Files";
+        string root = $"wwwroot{Path.DirectorySeparatorChar}Files";
         public FileManagerController(IWebHostEnvironment hostingEnvironment)
         {
             this.basePath = hostingEnvironment.ContentRootPath;
             this.operation = new PhysicalFileProvider();
-            this.operation.RootFolder(this.basePath + "\\" + this.root);
+            this.operation.RootFolder($"{this.basePath}{Path.DirectorySeparatorChar}{this.root}");
         }
         [Route("FileOperations")]
         public object FileOperations([FromBody] FileManagerDirectoryContent args)

--- a/Controllers/VirtualizationController.cs
+++ b/Controllers/VirtualizationController.cs
@@ -19,12 +19,12 @@ namespace EJ2APIServices.Controllers
     {
         public PhysicalFileProvider operation;
         public string basePath;
-        string root = "wwwroot\\FileBrowser";
+        string root = $"wwwroot{Path.DirectorySeparatorChar}Files";
         public VirtualizationController(IWebHostEnvironment hostingEnvironment)
         {
             this.basePath = hostingEnvironment.ContentRootPath;
             this.operation = new PhysicalFileProvider();
-            this.operation.RootFolder(this.basePath + "\\" + this.root);
+            this.operation.RootFolder($"{this.basePath}{Path.DirectorySeparatorChar}{this.root}");
         }
         [Route("FileOperations")]
         public object FileOperations([FromBody] FileManagerDirectoryContent args)


### PR DESCRIPTION
**Resolved the problem:**
When you run the project on a Linux/Unix based system, will give you the **_folder not found exception_**, because Windows use \ as a directory  separator character, while Linux/Unix based system use /